### PR TITLE
Use Cwd::realpath to find lib/

### DIFF
--- a/advanced_bin/git-rewrite-authors
+++ b/advanced_bin/git-rewrite-authors
@@ -6,7 +6,8 @@ use warnings;
 BEGIN {
   use File::Basename;
   use File::Spec;
-  my $dirname = dirname(__FILE__);
+  use Cwd;
+  my $dirname = dirname(Cwd::realpath(__FILE__));
   my $lib = File::Spec->catdir($dirname, File::Spec->updir(), 'lib');
   if(-d $lib) {
     unshift(@INC, $lib);

--- a/advanced_bin/git-simplecvs
+++ b/advanced_bin/git-simplecvs
@@ -19,7 +19,8 @@ use warnings;
 BEGIN {
   use File::Basename;
   use File::Spec;
-  my $dirname = dirname(__FILE__);
+  use Cwd;
+  my $dirname = dirname(Cwd::realpath(__FILE__));
   my $lib = File::Spec->catdir($dirname, File::Spec->updir(), 'lib');
   if(-d $lib) {
     unshift(@INC, $lib);


### PR DESCRIPTION
... like in the other scripts.
That's useful if advanced_bin/ is directly not in PATH, but its scripts are symlinked somewhere else accessible
