### PR TITLE
secondary_branch support in shallow_clone

### DIFF
--- a/bin/git-ensembl
+++ b/bin/git-ensembl
@@ -214,7 +214,7 @@ sub run_shallowclone {
     }
 
     print "* Cloning from remote '${remote_url}'\n";
-    if(! shallow_clone($remote_url, $verbose, $opts->{remote}, $opts->{depth}, $opts->{branch})) {
+    if(! shallow_clone($remote_url, $verbose, $opts->{remote}, $opts->{depth}, $opts->{branch}, $opts->{secondary_branch})) {
       print STDERR "! Failed to clone the module '$module'\n";
       return;
     }

--- a/lib/EnsEMBL/Git.pm
+++ b/lib/EnsEMBL/Git.pm
@@ -122,13 +122,23 @@ sub clone {
 
 # Perform a clone but do not bring everything down
 sub shallow_clone {
-  my ($remote_url, $verbose, $remote, $depth, $branch) = @_;
+  my ($remote_url, $verbose, $remote, $depth, $branch, $secondary_branch) = @_;
   $depth //= 1;
   $remote //= 'origin';
   my $v = $verbose ? '--verbose' : q{};
   my $b = $branch ? "--branch $branch" : q{};
   my $d = $depth ? "--depth $depth" : q{};
-  return system_ok("git clone -o $remote $v $d $b $remote_url");
+  
+  # try branch
+  my $rv = system_ok("git clone -o $remote $v $d $b $remote_url");
+
+  # if fail, try secondary_branch
+  if (!$rv) {
+    $b = $secondary_branch ? "--branch $secondary_branch" : q{};
+    $rv = system_ok("git clone -o $remote $v $d $b $remote_url");
+  }
+
+  return $rv;
 }
 
 # Perform a clone but do not create a working sandbox (so just the contents of .git)


### PR DESCRIPTION
In git-ensembl, the flag `--secondary_branch` can be used in conjunction with the `--clone`, `--checkout`, and `--pull` commands as a fallback if the original `--branch` is not found.
However, when using the `--shallow` flag,  `--secondary_branch` was ignored.
This fixes that issue.