### PR TITLE
Bugfix: parsing group names with uppercase letters.

### DIFF
--- a/bin/git-ensembl
+++ b/bin/git-ensembl
@@ -145,7 +145,7 @@ sub parse_command_line {
   if (!$opts->{list} && !@ARGV) {
     pod2usage(-exitval => 1, -verbose => 1, -msg => 'No groups specified; please specify some');
   }
-  $opts->{groups} = [ map {s/\/$//; lc($_)} @ARGV ];
+  $opts->{groups} = [ map {s/\/$//; $_} @ARGV ];
 
   return $opts;
 }


### PR DESCRIPTION
Fixes "module not found" error when the input command contains module/group names with uppercase characters.
Example: `git ensembl --clone VEP_plugins`